### PR TITLE
fix: testing x cards

### DIFF
--- a/src/pages/prize.tsx
+++ b/src/pages/prize.tsx
@@ -95,7 +95,7 @@ export const Head: HeadFC<{}, { langKey?: string }> = (props) => {
       <meta
         id="twitter:image"
         name="twitter:image"
-        content="https://graypaper.com/img/opengraph.png"
+        content="https://graypaper.com/img/opengraph-rect.png"
       />
 
       <html id="html" lang={i18n.language} />

--- a/src/pages/prize.tsx
+++ b/src/pages/prize.tsx
@@ -95,7 +95,7 @@ export const Head: HeadFC<{}, { langKey?: string }> = (props) => {
       <meta
         id="twitter:image"
         name="twitter:image"
-        content="https://graypaper.com/img/opengraph-rect.png"
+        content="https://deploy-preview-64--graypaper.netlify.app/img/opengraph.png"
       />
 
       <html id="html" lang={i18n.language} />


### PR DESCRIPTION
This branch is just for testing if the preview images are picked up by twitter now. This branch deployment works now. The changes are already in main but it seems that twitter is caching the previous fetched data. Will wait a bit and test again if fix images are picked up now.

This link should work on twitter:
```
https://deploy-preview-64--graypaper.netlify.app/prize/
```

<img width="595" alt="Screenshot 2024-12-12 at 08 03 30" src="https://github.com/user-attachments/assets/d67c86f1-6efc-4afc-9e26-1d111ed3eaaa" />
