### PR TITLE
JAM Implementer DAO Seeding: JAM DUNA

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -152,6 +152,7 @@ export const clients: ClientData[] = [
     name: "JAM DUNA",
     languages: [{ name: "Go", set: "A" }],
     milestone: 0,
+    address: "121Rs6fKm8nguHnvPfG1Cq3ctFuNAVZGRmghwkJwHpKxKjbx",
     contact: ["@sourabhniyogi:matrix.org"],
   },
   {


### PR DESCRIPTION
Background:
https://forum.polkadot.network/t/decentralized-voices-cohort-4-jam-implementers-dao/12001

We would like JAM DAO members (implementers only now, maybe service builders later) to provide addresses here in this repo to support a Telegram bot

https://github.com/permanence-dao/permanence-dao-services/tree/main/pdao-telegram-bot

so that the "1 implementer, 1 vote" can be powered by the registered addresses here.  The expectation is that this simple Sybil mechanism can limit membership to just JAM implementers who are actually building JAM clients and expend the energy to at least register themselves here.

The address here doesn't need to be linked to the site, and for now is only for DAO participation (in OpenSquare, onchain voting via the above Telegram bot) and has nothing to do with JAM prize payment.  But it might be used in a AssetHub context or Collectives context by the end of the year or in 2026.  

Also, not sure if the extra field will break anything on the site -- it might need to be provisioned in some data structure.