### PR TITLE
Update client name from `RJAM` to `FastRoll`

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -243,7 +243,7 @@ export const clients: ClientData[] = [
   {
     description: "JAM Rust client implementation.",
     homepage: "",
-    name: "RJAM",
+    name: "FastRoll",
     languages: [{ name: "Rust", set: "B" }],
     milestone: 0,
     contact: ["@0xjunha:matrix.org"],


### PR DESCRIPTION
I added `RJAM` client (#22) with the same gh account opening this PR (`0xa11ce`) and want to change the name into `FastRoll`.
Thank you.