### PR TITLE
Add Jam on the Lisp client listing

### DIFF
--- a/src/data/clients.ts
+++ b/src/data/clients.ts
@@ -384,4 +384,12 @@ export const clients: ClientData[] = [
     milestone: 0,
     contact: ["@shimonchick:matrix.org"],
   },
+  {
+    description: "A JAM implementation in LISP.",
+    homepage: "https://github.com/polykrate/JOTL/",
+    name: "Jam on the Lisp",
+    languages: [{ name: "Common Lisp", set: "C" }],
+    milestone: 0,
+    contact: [],
+  },
 ]


### PR DESCRIPTION
- Name: Jam on the Lisp
- Description: A JAM implementation in LISP
- Homepage: https://github.com/polykrate/JOTL/
- Language: Common Lisp (Set C)
- Milestone: 0

Closes #166